### PR TITLE
Upgrade to Spree 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ spec/dummy/db/*.sqlite3
 spec/dummy/db/schema.rb
 spec/dummy/db/migrate/*.rb
 spec/dummy/public/*
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ spec/dummy/db/schema.rb
 spec/dummy/db/migrate/*.rb
 spec/dummy/public/*
 .idea
+.generators

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :development, :test do
+  gem 'spree_auth_devise'
+end

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,7 +1,15 @@
-Spree::Payment.class_eval do
-  scope :from_purchase_order, -> { where(source_type: 'Spree::PurchaseOrder') }
+module Spree
+  module PaymentDecorator
+    def self.prepended(base)
+      base.scope :from_purchase_order, -> { where(source_type: 'Spree::PurchaseOrder') }
+    end
 
-  def po?
-    source_type == 'Spree::PurchaseOrder'
+    def po?
+      source_type == 'Spree::PurchaseOrder'
+    end
   end
+end
+
+if ::Spree::Payment.included_modules.exclude?(::Spree::PaymentDecorator)
+  ::Spree::Payment.prepend ::Spree::PaymentDecorator
 end

--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,7 +1,12 @@
+# frozen_string_literal: true
+
 module Spree
   module PaymentDecorator
     def self.prepended(base)
-      base.scope :from_purchase_order, -> { where(source_type: 'Spree::PurchaseOrder') }
+      base.scope(
+        :from_purchase_order,
+        -> { where(source_type: 'Spree::PurchaseOrder') }
+      )
     end
 
     def po?

--- a/app/models/spree/payment_method/purchase_order.rb
+++ b/app/models/spree/payment_method/purchase_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   class PaymentMethod::PurchaseOrder < PaymentMethod
     def payment_source_class

--- a/app/models/spree/purchase_order.rb
+++ b/app/models/spree/purchase_order.rb
@@ -5,7 +5,7 @@ module Spree
     belongs_to :payment_method
     has_many :payments, as: :source
 
-    validates_presence_of :po_number, :organization_name
+    validates :po_number, :organization_name, presence: true
 
     def actions
       %w(complete void)

--- a/app/models/spree/purchase_order.rb
+++ b/app/models/spree/purchase_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   class PurchaseOrder < Spree::Base
     belongs_to :payment_method

--- a/app/views/spree/checkout/payment/_purchaseorder.html.erb
+++ b/app/views/spree/checkout/payment/_purchaseorder.html.erb
@@ -1,15 +1,13 @@
-<div class='well clearfix'>
+<div class="payment-gateway">
   <% param_prefix = "payment_source[#{payment_method.id}]" %>
-  <p class='field'>
-    <%= label_tag :po_number do %>
-      <%= Spree.t(:po_number) %><abbr class='required' title='required'>*</abbr>
-    <% end %>
-    <%= text_field_tag "#{param_prefix}[po_number]", '', id: :po_number, class: 'form-control required', size: 10, maxlength: 10, autocomplete: "off" %>
-  </p>
-  <p class='field'>
-    <%= label_tag :organization_name do %>
-      <%= Spree.t(:organization_name) %><abbr class='required' title='required'>*</abbr>
-    <% end %>
-    <%= text_field_tag "#{param_prefix}[organization_name]", '', id: :organization_name, class: 'form-control required'%>
-  </p>
+
+  <div class="payment-gateway-fields">
+    <div class="mb-4 payment-gateway-field checkout-content-inner-field">
+      <%= text_field_tag "#{param_prefix}[po_number]", '', id: 'po_number', class: 'spree-flat-input', placeholder: Spree.t(:po_number) %>
+    </div>
+
+    <div class="payment-gateway-field checkout-content-inner-field">
+      <%= text_field_tag "#{param_prefix}[organization_name]", '', id: 'organization_name', class: 'spree-flat-input', placeholder: Spree.t(:organization_name) %>
+    </div>
+  </div>
 </div>

--- a/app/views/spree/checkout/payment/_purchaseorder.html.erb
+++ b/app/views/spree/checkout/payment/_purchaseorder.html.erb
@@ -3,11 +3,11 @@
 
   <div class="payment-gateway-fields">
     <div class="mb-4 payment-gateway-field checkout-content-inner-field">
-      <%= text_field_tag "#{param_prefix}[po_number]", '', id: 'po_number', class: 'spree-flat-input', placeholder: Spree.t(:po_number) %>
+      <%= text_field_tag "#{param_prefix}[po_number]", '', id: 'po_number', class: 'spree-flat-input', placeholder: Spree.t(:po_number), required: true %>
     </div>
 
     <div class="payment-gateway-field checkout-content-inner-field">
-      <%= text_field_tag "#{param_prefix}[organization_name]", '', id: 'organization_name', class: 'spree-flat-input', placeholder: Spree.t(:organization_name) %>
+      <%= text_field_tag "#{param_prefix}[organization_name]", '', id: 'organization_name', class: 'spree-flat-input', placeholder: Spree.t(:organization_name), required: true %>
     </div>
   </div>
 </div>

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -21,6 +21,8 @@ module Dummy
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end
+
+    config.load_defaults 6.0
   end
 end
 

--- a/spec/factories/purchase_orders.rb
+++ b/spec/factories/purchase_orders.rb
@@ -37,6 +37,7 @@ FactoryBot.define do
     name { 'Spree Test Store' }
     url { 'www.example.com' }
     mail_from_address { 'spree@example.org' }
+    default_currency { 'USD' }
   end
 
   # factory :user, class: Spree.user_class do

--- a/spree_purchase_order.gemspec
+++ b/spree_purchase_order.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.7.0'
+  s.add_dependency 'spree_core', '~> 4.0'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
I changed the dependency requirement so this gem could be used with new Spree projects.

I didn't have any issues using this fork on an existing project. From what I can tell, no other changes are needed to get this working (but I'm happy to do anything else if that's not the case).

Also, I noticed there's a branch called `4-0-stable` that doesn't really differ from `master`. If you want I can rebase my changes so they'll be merged into that branch instead.